### PR TITLE
Remove unwanted slashes conversion in paths

### DIFF
--- a/synocli.py
+++ b/synocli.py
@@ -146,9 +146,9 @@ import binascii
 import argparse
 import threading
 import concurrent.futures
-from pathlib import Path
 from pprint import pformat
 from collections import defaultdict
+from pathlib import Path, PurePosixPath
 from logging import debug, info, warning, error
 
 import tqdm
@@ -304,9 +304,9 @@ class Syno(object):
 
     def get(self, basepath, outpath=None, recursive=False, progress=True, download_threads=DOWNLOAD_THREADS_DEFAULT):
         session = self.session[0]
-        # ensure path is a Path
+        # ensure path is a native PosixPath or could be converted to it before sending to SYNOLOGY (for windows users)
         if type(basepath) is str:
-            basepath = Path(basepath)
+            basepath = PurePosixPath(basepath)
         # ensure outpath is a Path, except if stdout
         if outpath is None:
             outpath = Path('.').absolute()
@@ -379,7 +379,7 @@ class Syno(object):
                             if not outpath.exists():
                                 outpath.mkdir()
                         for d in lsjson["data"]["files"]:
-                            path = Path(d["path"])
+                            path = PurePosixPath(d["path"])
                             if d["isdir"]:
                                 stats['dir_count'] += 1
                                 relativepath = path.relative_to(basepath)


### PR DESCRIPTION
Ensure that SYNOLOGY will receive POSIX paths and names in list and get requests

Was not working in windows, due to  paths being converted to 'backslashed' notation even if the user have provided correct slashes in console